### PR TITLE
version: sync to 1.6.0 (Convex plugin family)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convex",
-  "version": "1.0.0",
+  "version": "1.6.0",
   "description": "Official Convex plugin for Cursor - reactive backend development with TypeScript, including rules, skills, MCP integration, and automation hooks",
   "author": {
     "name": "Convex",


### PR DESCRIPTION
Coordinated version number across the three Convex plugins (Claude / Codex / Cursor) so a release maps to one number.

No functional change — the Cursor plugin already ships the capabilities the Claude/Codex betas just gained (official Convex MCP, `convex-reviewer`, the commit-checks hook were ported **from** here). This is the version-sync half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)