### PR TITLE
revert: Cursor version 1.6.0 → 1.0.0

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convex",
-  "version": "1.6.0",
+  "version": "1.0.0",
   "description": "Official Convex plugin for Cursor - reactive backend development with TypeScript, including rules, skills, MCP integration, and automation hooks",
   "author": {
     "name": "Convex",


### PR DESCRIPTION
The 1.6.0 bump was a cross-plugin version-sync, but `convex-agent-plugins` is the official public Cursor plugin — a different tier from the staging Codex/Claude betas. Revert to its own line.