### PR TITLE
Add Claude Code plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "convex-agent-plugins",
+  "description": "Official Convex plugins for AI coding agents",
+  "owner": {
+    "name": "Convex",
+    "email": "support@convex.dev"
+  },
+  "plugins": [
+    {
+      "name": "convex",
+      "source": "./",
+      "description": "Official Convex plugin for Claude Code - reactive backend development with TypeScript, including agents, skills, MCP integration, and automation hooks"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "convex",
+  "version": "1.0.0",
+  "description": "Official Convex plugin for Claude Code - reactive backend development with TypeScript, including agents, skills, MCP integration, and automation hooks",
+  "author": {
+    "name": "Convex",
+    "email": "support@convex.dev"
+  },
+  "homepage": "https://convex.dev",
+  "repository": "https://github.com/get-convex/convex-agent-plugins",
+  "license": "MIT",
+  "keywords": [
+    "convex",
+    "backend",
+    "database",
+    "realtime",
+    "typescript",
+    "reactive",
+    "serverless"
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "convex": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "convex@latest",
+        "mcp",
+        "start"
+      ]
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ Before submitting:
    cp -r . ~/.cursor/plugins/convex
 
    # For Claude Code
-   ln -s $(pwd) ~/.claude/plugins/convex
+   claude --plugin-dir $(pwd)
    ```
 
 2. **Rule Test**

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This plugin makes Convex development easier by providing:
 
 ## Installation
 
+### Cursor
+
 Install this plugin via the Cursor Marketplace or manually:
 
 ```bash
@@ -34,6 +36,24 @@ cd ~/.cursor/plugins
 git clone <this-repo-url> convex
 
 # Restart Cursor
+```
+
+### Claude Code
+
+Add this repo as a plugin marketplace, then install the `convex` plugin:
+
+```bash
+claude
+/plugin marketplace add get-convex/convex-agent-plugins
+/plugin install convex@convex-agent-plugins
+```
+
+Skills are namespaced, so invoke them as `/convex:convex-quickstart`, `/convex:schema-builder`, etc.
+
+For local development without installing, load it directly:
+
+```bash
+claude --plugin-dir /path/to/convex-agent-plugins
 ```
 
 ## Components
@@ -67,6 +87,8 @@ The plugin includes 18 rules that provide persistent AI guidance:
 Plus contextual rules for new projects, real-time features, and deployment workflows.
 
 Rules automatically guide the AI when working in your `convex/` directory.
+
+> **Note:** Rules use Cursor's `.mdc` format and currently apply to Cursor only. Claude Code loads this plugin's skills, agents, MCP server, and hooks.
 
 ### Skills (On-Demand Expertise)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/claude-pre-commit-checks.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/claude-pre-commit-checks.sh
+++ b/scripts/claude-pre-commit-checks.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# PreToolUse hook for git commit checks (Claude Code).
+# Reads the Bash tool_input JSON on stdin and, for git commit commands,
+# blocks via hookSpecificOutput if Convex anti-patterns are detected.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib-hook-checks.sh
+source "${SCRIPT_DIR}/lib-hook-checks.sh"
+
+HOOK_INPUT="$(cat)"
+if [ -z "$HOOK_INPUT" ]; then
+  exit 0
+fi
+
+ONE_LINE_INPUT="${HOOK_INPUT//$'\n'/}"
+ONE_LINE_INPUT="${ONE_LINE_INPUT//$'\r'/}"
+
+COMMAND="$(json_get_string "$ONE_LINE_INPUT" "command" || true)"
+HOOK_CWD="$(json_get_string "$ONE_LINE_INPUT" "cwd" || true)"
+
+# Extra safety guard beyond the hooks.json matcher/if.
+if [[ ! "$COMMAND" =~ (^|[[:space:]])git[[:space:]]+commit($|[[:space:]]) ]]; then
+  exit 0
+fi
+
+REPO_ROOT="$HOOK_CWD"
+if [ -z "$REPO_ROOT" ] && [ -d "${SCRIPT_DIR}/../.git" ]; then
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+fi
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+VIOLATION="$(convex_check_violation "${REPO_ROOT}/convex")"
+
+REASON=""
+case "$VIOLATION" in
+  date_now)
+    REASON="Commit blocked: Date.now() detected near query({}) in convex/. Queries should be deterministic for reactivity. Use server-generated timestamps in writes or pass time as an argument."
+    ;;
+  filter)
+    REASON="Commit blocked: .filter() detected on db.query() in convex/. Prefer indexed access patterns such as .withIndex() for performance and correctness."
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$REASON"
+exit 0

--- a/scripts/lib-hook-checks.sh
+++ b/scripts/lib-hook-checks.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Shared JSON parsing helpers and Convex anti-pattern checks used by both the
+# Cursor (pre-commit-checks.sh) and Claude Code (claude-pre-commit-checks.sh)
+# git-commit hooks.
+
+ltrim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  printf '%s' "$value"
+}
+
+json_parse_quoted_string() {
+  local text="$1"
+  local out=""
+  local escaped=0
+  local i
+  local ch
+
+  if [ "${text:0:1}" != '"' ]; then
+    return 1
+  fi
+  text="${text:1}"
+
+  for ((i = 0; i < ${#text}; i++)); do
+    ch="${text:i:1}"
+    if [ "$escaped" -eq 1 ]; then
+      case "$ch" in
+        \"|\\|/) out+="$ch" ;;
+        b) out+=$'\b' ;;
+        f) out+=$'\f' ;;
+        n) out+=$'\n' ;;
+        r) out+=$'\r' ;;
+        t) out+=$'\t' ;;
+        u)
+          # Keep unicode escapes as-is for safety.
+          out+="\\u${text:i+1:4}"
+          i=$((i + 4))
+          ;;
+        *) out+="$ch" ;;
+      esac
+      escaped=0
+      continue
+    fi
+
+    case "$ch" in
+      \\) escaped=1 ;;
+      \")
+        printf '%s' "$out"
+        return 0
+        ;;
+      *) out+="$ch" ;;
+    esac
+  done
+
+  return 1
+}
+
+json_get_string() {
+  local json="$1"
+  local key="$2"
+  local rest
+
+  rest="${json#*\"${key}\"}"
+  if [ "$rest" = "$json" ]; then
+    return 1
+  fi
+  rest="${rest#*:}"
+  rest="$(ltrim "$rest")"
+  json_parse_quoted_string "$rest"
+}
+
+json_get_first_array_string() {
+  local json="$1"
+  local key="$2"
+  local rest
+
+  rest="${json#*\"${key}\"}"
+  if [ "$rest" = "$json" ]; then
+    return 1
+  fi
+  rest="${rest#*:}"
+  rest="$(ltrim "$rest")"
+  if [ "${rest:0:1}" != "[" ]; then
+    return 1
+  fi
+  rest="${rest:1}"
+  rest="$(ltrim "$rest")"
+  json_parse_quoted_string "$rest"
+}
+
+# Checks a Convex functions directory for known anti-patterns.
+# Prints "date_now", "filter", or nothing (via stdout) and always returns 0.
+convex_check_violation() {
+  local convex_dir="$1"
+
+  if [ ! -d "$convex_dir" ]; then
+    return 0
+  fi
+
+  # Block Date.now() in query functions.
+  local date_now_in_queries
+  date_now_in_queries="$(
+    grep -r "Date\.now()" "$convex_dir"/ --include="*.ts" --include="*.js" \
+      | grep -B 5 "query({" \
+      | grep "Date\.now()" || true
+  )"
+  if [ -n "$date_now_in_queries" ]; then
+    printf 'date_now'
+    return 0
+  fi
+
+  # Block .filter() chained from Convex db.query().
+  local filter_on_queries
+  filter_on_queries="$(
+    grep -r "\.query(.*)\s*\.filter(" "$convex_dir"/ --include="*.ts" --include="*.js" || true
+  )"
+  if [ -n "$filter_on_queries" ]; then
+    printf 'filter'
+    return 0
+  fi
+
+  return 0
+}

--- a/scripts/pre-commit-checks.sh
+++ b/scripts/pre-commit-checks.sh
@@ -1,92 +1,11 @@
 #!/bin/bash
 
-# beforeShellExecution hook for git commit checks.
+# beforeShellExecution hook for git commit checks (Cursor).
 # Returns JSON only on stdout.
 
-ltrim() {
-  local value="$1"
-  value="${value#"${value%%[![:space:]]*}"}"
-  printf '%s' "$value"
-}
-
-json_parse_quoted_string() {
-  local text="$1"
-  local out=""
-  local escaped=0
-  local i
-  local ch
-
-  if [ "${text:0:1}" != '"' ]; then
-    return 1
-  fi
-  text="${text:1}"
-
-  for ((i = 0; i < ${#text}; i++)); do
-    ch="${text:i:1}"
-    if [ "$escaped" -eq 1 ]; then
-      case "$ch" in
-        \"|\\|/) out+="$ch" ;;
-        b) out+=$'\b' ;;
-        f) out+=$'\f' ;;
-        n) out+=$'\n' ;;
-        r) out+=$'\r' ;;
-        t) out+=$'\t' ;;
-        u)
-          # Keep unicode escapes as-is for safety.
-          out+="\\u${text:i+1:4}"
-          i=$((i + 4))
-          ;;
-        *) out+="$ch" ;;
-      esac
-      escaped=0
-      continue
-    fi
-
-    case "$ch" in
-      \\) escaped=1 ;;
-      \")
-        printf '%s' "$out"
-        return 0
-        ;;
-      *) out+="$ch" ;;
-    esac
-  done
-
-  return 1
-}
-
-json_get_string() {
-  local json="$1"
-  local key="$2"
-  local rest
-
-  rest="${json#*\"${key}\"}"
-  if [ "$rest" = "$json" ]; then
-    return 1
-  fi
-  rest="${rest#*:}"
-  rest="$(ltrim "$rest")"
-  json_parse_quoted_string "$rest"
-}
-
-json_get_first_array_string() {
-  local json="$1"
-  local key="$2"
-  local rest
-
-  rest="${json#*\"${key}\"}"
-  if [ "$rest" = "$json" ]; then
-    return 1
-  fi
-  rest="${rest#*:}"
-  rest="$(ltrim "$rest")"
-  if [ "${rest:0:1}" != "[" ]; then
-    return 1
-  fi
-  rest="${rest:1}"
-  rest="$(ltrim "$rest")"
-  json_parse_quoted_string "$rest"
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib-hook-checks.sh
+source "${SCRIPT_DIR}/lib-hook-checks.sh"
 
 allow() {
   printf '%s\n' '{"permission":"allow"}'
@@ -120,7 +39,6 @@ if [[ ! "$COMMAND" =~ (^|[[:space:]])git[[:space:]]+commit($|[[:space:]]) ]]; th
   allow
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$WORKSPACE_ROOT"
 if [ -z "$REPO_ROOT" ]; then
   REPO_ROOT="$HOOK_CWD"
@@ -132,30 +50,17 @@ if [ -z "$REPO_ROOT" ]; then
   allow
 fi
 
-CONVEX_DIR="${REPO_ROOT}/convex"
-if [ ! -d "$CONVEX_DIR" ]; then
-  allow
-fi
-
-# Block Date.now() in query functions.
-DATE_NOW_IN_QUERIES="$(
-  grep -r "Date\.now()" "$CONVEX_DIR"/ --include="*.ts" --include="*.js" \
-    | grep -B 5 "query({" \
-    | grep "Date\.now()" || true
-)"
-if [ -n "$DATE_NOW_IN_QUERIES" ]; then
-  deny \
-    "Commit blocked: found Date.now() inside/near Convex query functions." \
-    "beforeShellExecution blocked this git commit because Date.now() was detected near query({}) in convex/. Queries should be deterministic for reactivity. Use server-generated timestamps in writes or pass time as an argument."
-fi
-
-# Block .filter() chained from Convex db.query().
-FILTER_ON_QUERIES="$(
-  grep -r "\.query(.*)\s*\.filter(" "$CONVEX_DIR"/ --include="*.ts" --include="*.js" || true
-)"
-if [ -n "$FILTER_ON_QUERIES" ]; then
-  deny \
-    "Commit blocked: found .filter() on Convex db.query() calls." \
-    "beforeShellExecution blocked this git commit because .filter() was detected on db.query() in convex/. Prefer indexed access patterns such as .withIndex() for performance and correctness."
-fi
+VIOLATION="$(convex_check_violation "${REPO_ROOT}/convex")"
+case "$VIOLATION" in
+  date_now)
+    deny \
+      "Commit blocked: found Date.now() inside/near Convex query functions." \
+      "beforeShellExecution blocked this git commit because Date.now() was detected near query({}) in convex/. Queries should be deterministic for reactivity. Use server-generated timestamps in writes or pass time as an argument."
+    ;;
+  filter)
+    deny \
+      "Commit blocked: found .filter() on Convex db.query() calls." \
+      "beforeShellExecution blocked this git commit because .filter() was detected on db.query() in convex/. Prefer indexed access patterns such as .withIndex() for performance and correctness."
+    ;;
+esac
 allow


### PR DESCRIPTION
## Summary

The repo's `agents/`, `skills/`, `mcp.json`, and `scripts/` are already laid out to match Claude Code's plugin conventions (`agents/*.md`, `skills/<name>/SKILL.md`), but there was no `.claude-plugin/plugin.json` manifest, so the repo could not actually be installed as a Claude Code plugin despite the README already listing "Claude Code" as supported.

- Add `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` so the repo installs directly via `/plugin marketplace add get-convex/convex-agent-plugins` + `/plugin install convex@convex-agent-plugins`, reusing the existing `skills/`, `agents/`, and MCP config.
- Add `.mcp.json` (Claude's `mcpServers` schema) alongside the existing Cursor `mcp.json`.
- Add `hooks/hooks.json` (Claude's `PreToolUse` hook format) plus `scripts/claude-pre-commit-checks.sh`, porting the git-commit checks (`Date.now()` in queries, `.filter()` on `db.query()`) to Claude's hook protocol.
- Factor the shared JSON-parsing/check logic out of `scripts/pre-commit-checks.sh` into `scripts/lib-hook-checks.sh` so the Cursor hook's behavior is unchanged (same allow/deny output verified before/after).
- Update README/CONTRIBUTING with Claude Code install & local test instructions. Note that the 18 Cursor `.mdc` rules have no direct Claude Code plugin equivalent (no "always active, glob-scoped" component in Claude's plugin system) and remain Cursor-only for now.

## Test plan

- [x] `claude plugin validate .` passes clean (no warnings/errors)
- [x] `claude --plugin-dir .` loads the plugin; skills, agents, and the `convex` MCP server all appear
- [x] End-to-end: `git commit` in a test repo with a `.filter()` anti-pattern is blocked by the new Claude hook with a clear reason
- [x] Verified `scripts/pre-commit-checks.sh` (Cursor) produces identical output before and after the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)