### PR TITLE
launch: barebones quickstart + custom-domains rules

### DIFF
--- a/rules/custom-domains.mdc
+++ b/rules/custom-domains.mdc
@@ -1,0 +1,23 @@
+---
+description: Wire a domain the user already owns (own registrar) to their Convex app — DNS records, custom-domain attach, auth-origin rebind
+globs:
+alwaysApply: false
+---
+
+# Custom domain with your own provider
+
+When the user already OWNS a domain (GoDaddy/Namecheap/Cloudflare/…) and wants it
+pointing at their Convex app:
+
+1. Identify the target: the published site host or the deployment's HTTP actions
+   URL (`npx convex env get CONVEX_SITE_URL`).
+2. Give the EXACT DNS records to create at their registrar: the CNAME (or A/ALIAS
+   at the apex) plus the TXT verification record — concrete host/value strings.
+3. Attach the custom domain on Convex (dashboard → Custom Domains) and wait for
+   verification; DNS propagation can take minutes to hours.
+4. If the app uses auth, rebind the auth origin (`SITE_URL`/`RP_ID`/`ORIGIN`) and
+   re-deploy — otherwise sign-in breaks on the new domain.
+5. Verify HTTPS serving, including the apex → www redirect if configured.
+
+Rules: NEVER ask for registrar credentials; always include the TXT record; if
+the user wants to FIND/BUY a domain, that flow is not in this plugin yet.

--- a/rules/quickstart.mdc
+++ b/rules/quickstart.mdc
@@ -1,0 +1,22 @@
+---
+description: Get a barebones Convex + web template running from a one-sentence idea (new projects only)
+globs:
+alwaysApply: false
+---
+
+# Convex quickstart (barebones)
+
+When the user wants to START a new app from a one-sentence idea and there is no
+Convex project in the workspace:
+
+1. Scaffold the minimal template: `npm create convex@latest` (choose Next.js when
+   the user wants a web app), or clone the `next-shadcn` template.
+2. Install deps, then start BOTH dev processes: `npx convex dev` (accept the
+   anonymous dev deployment — no login needed) and the web dev server.
+3. Open the printed dev URL for the user, present a short plan, and CONFIRM
+   before building features beyond the template.
+
+Rules: never re-scaffold into an existing Convex project; delegate code under
+`convex/` to the convex conventions rules; don't add Postgres/Redis/Express —
+use Convex primitives. This is the barebones flow: no hosting/publish step, no
+feedback panel, no auth pre-bake.


### PR DESCRIPTION
Core-wave launch: adds the barebones `quickstart` rule (Cursor previously had no quickstart at all) and the `custom-domains` rule (BYO-provider wiring, no credentials). Labs features (wow shell, domain buying) intentionally absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)