### PR TITLE
Cursor: stop-hook end-of-turn verify mechanism (v1.3.0 -> v1.4.0)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convex",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Official Convex plugin for Cursor - reactive backend development with TypeScript, including rules, skills, MCP integration, and automation hooks",
   "author": {
     "name": "Convex",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin makes Convex development easier by providing:
 - **6 Specialized Skills** — Expert agent capabilities including quickstart, schema building, function creation, authentication, and migrations
 - **2 Custom Agents** — Specialized advisor and code reviewer for Convex development
 - **MCP Integration** — Direct access to your Convex deployment data and operations
-- **Development Hooks** — Automated validation, codegen, and pre-commit checks
+- **Development Hooks** — pre-commit checks (blocking) and an end-of-turn verify retry-loop (non-blocking; see [Cursor plugin mechanism status](#cursor-plugin-mechanism-status))
 
 ## What is Convex?
 
@@ -186,28 +186,38 @@ export CONVEX_DEPLOY_KEY="your-deploy-key"
 
 ### Development Hooks
 
-Automated checks and operations triggered by file changes:
+The plugin ships two Cursor hooks (`hooks.json`, wired via `.cursor-plugin/plugin.json`'s
+`hooks` field — see [Cursor's hooks docs](https://cursor.com/docs/hooks) for the
+full event list and schema). These are real Cursor mechanisms, not just
+instructions: each is a spawned script that Cursor calls automatically and
+whose JSON output Cursor acts on.
 
-#### Pre-Save Validation
-Validates Convex functions have proper `args` and `returns` validators.
+#### Pre-Commit Checks (`beforeShellExecution`)
+Runs before any shell command matching `git commit`; can **deny** the commit
+outright.
 
-- **Triggers on:** Save in `convex/**/*.ts` or `convex/**/*.js`
-- **Checks:** Function exports have args and returns defined
+- **Checks:** `Date.now()` inside/near `query({...})` bodies, `.filter()`
+  chained on `db.query(...)`.
+- **Script:** `scripts/pre-commit-checks.sh`
 
-#### Post-Save Codegen
-Automatically runs Convex codegen after schema changes.
+#### End-of-Turn Verify (`stop`)
+Fires when the agent's turn ends (`status: "completed"`). Cursor's `stop`
+hook **cannot block** completion — but it can return a `followup_message`
+that Cursor automatically submits as the next user turn, capped by
+`loop_limit` (set to `2` here) so it can't loop forever. This turns the
+SELF-VERIFY RULE already in `rules/quickstart.mdc` (run `npx tsc --noEmit`
+before declaring backend work done) from an instruction the agent might
+forget into a mechanism that catches it if it does: if `convex/` exists and
+`npx tsc --noEmit` fails, the hook auto-submits a follow-up turn with the
+compiler errors so the agent fixes them before the session is really "done".
 
-- **Triggers on:** Save in `convex/schema.ts`
-- **Action:** Runs `npx convex codegen --dev`
-
-#### Pre-Commit Checks
-Runs ESLint, type checking, and common issue detection before commits.
-
-- **Checks:**
-  - ESLint on Convex functions
-  - TypeScript type checking
-  - Date.now() in queries (warning)
-  - .filter() on database queries (warning)
+- **Script:** `scripts/stop-verify.sh`
+- **Honest limitation:** this is a retry-loop, not a hard gate — Cursor has
+  no hook that blocks turn completion the way Claude Code's `Stop` hook or a
+  CI gate would. A user who ignores the follow-up (or an agent that exhausts
+  the loop limit) can still end the session with a broken build. See
+  [Cursor plugin mechanism status](#cursor-plugin-mechanism-status) below for
+  how this compares to the Claude Code and Codex equivalents.
 
 ## Usage Examples
 
@@ -317,6 +327,30 @@ npm install convex
 # or
 npm install convex@latest
 ```
+
+## Cursor plugin mechanism status
+
+Convex ships an end-of-turn "verify before you say you're done" mechanism
+across the coding agents it supports, but the *strength* of that mechanism
+depends on what each agent's plugin format actually offers:
+
+| Agent | Mechanism | Enforcement |
+|---|---|---|
+| Claude Code | `Stop` hook | Can block: the hook can require the agent keep working before the turn is allowed to end. |
+| Codex | MCP server leg (`fix_errors_automatically`) | Blocking tool call: the agent's own idle loop calls a tool that blocks until a real event (including a compile error) fires. |
+| **Cursor** | `stop` hook → `followup_message` (`scripts/stop-verify.sh`) | **Not blocking.** Cursor's `stop` hook cannot prevent a turn from ending; it can only auto-submit a follow-up message (capped at `loop_limit: 2` here) asking the agent to fix what the hook found. A user can still walk away from a broken build if they ignore the follow-up or the loop limit is hit. |
+
+This is a real, Cursor-native mechanism — not just the static SELF-VERIFY RULE
+text in `rules/quickstart.mdc` — but it is a retry-loop, not a gate.
+Cursor's plugin format has no hook that blocks turn completion the way
+Claude Code's `Stop` hook does (confirmed against
+[Cursor's hooks documentation](https://cursor.com/docs/hooks): the `stop`
+event's own docs state it fires "when the agent loop ends" and its only
+output field is the informational/loop-triggering `followup_message` — there
+is no `permission`/block field on that event, unlike `beforeShellExecution`
+which this plugin already uses to hard-deny bad `git commit`s). If Cursor
+ships a blocking end-of-turn hook in the future, this is the file to upgrade
+(`scripts/stop-verify.sh` + the `stop` entry in `hooks.json`).
 
 ## Learn More
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -344,7 +344,18 @@ export const broken = query({
 
 ## Testing Hooks
 
-Hooks run automatically on file events. To test:
+### Automated: the `stop` hook (end-of-turn verify)
+
+```bash
+./test-harness/test-stop-verify.sh
+```
+
+This is self-contained (no Cursor install needed): it feeds `scripts/stop-verify.sh`
+the same JSON on stdin that Cursor's `stop` hook would, across fixtures
+(no `convex/` dir, non-`completed` status, loop-limit reached, passing
+`tsc --noEmit`, failing `tsc --noEmit`) and checks the JSON it prints back.
+
+### Manual: hooks run automatically on file/shell events. To test:
 
 ### Test: Pre-save validation
 

--- a/hooks.json
+++ b/hooks.json
@@ -6,6 +6,12 @@
         "command": "./scripts/pre-commit-checks.sh",
         "matcher": "\\bgit\\s+commit\\b"
       }
+    ],
+    "stop": [
+      {
+        "command": "./scripts/stop-verify.sh",
+        "loop_limit": 2
+      }
     ]
   }
 }

--- a/scripts/stop-verify.sh
+++ b/scripts/stop-verify.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+# stop hook for end-of-turn Convex verification.
+#
+# Cursor's `stop` hook fires when the agent loop ends (status: completed |
+# aborted | error) and cannot block completion, but it CAN return a
+# `followup_message` that Cursor automatically submits as the next user
+# message (docs: https://cursor.com/docs/hooks, section "stop" — "Can
+# optionally auto-submit a follow-up user message to keep iterating.").
+# That's the real enforcement lever available to a Cursor plugin: not a
+# gate, but an automatic re-prompt loop, capped by `loop_limit` (see
+# hooks.json) so it can't run forever.
+#
+# This mirrors the SELF-VERIFY RULE already shipped in rules/quickstart.mdc
+# (run `npx tsc --noEmit` before declaring backend work done) but makes it a
+# mechanism instead of an instruction: if the agent forgets/skips the rule,
+# this hook catches it at turn-end and forces a follow-up turn with the
+# actual compiler errors.
+#
+# Only acts on `status: "completed"` — an aborted/errored turn already has
+# the user's attention, so we don't pile on. Only acts when a convex/
+# directory exists in the workspace. Returns JSON only on stdout.
+
+ltrim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  printf '%s' "$value"
+}
+
+json_parse_quoted_string() {
+  local text="$1"
+  local out=""
+  local escaped=0
+  local i
+  local ch
+
+  if [ "${text:0:1}" != '"' ]; then
+    return 1
+  fi
+  text="${text:1}"
+
+  for ((i = 0; i < ${#text}; i++)); do
+    ch="${text:i:1}"
+    if [ "$escaped" -eq 1 ]; then
+      case "$ch" in
+        \"|\\|/) out+="$ch" ;;
+        b) out+=$'\b' ;;
+        f) out+=$'\f' ;;
+        n) out+=$'\n' ;;
+        r) out+=$'\r' ;;
+        t) out+=$'\t' ;;
+        u)
+          out+="\\u${text:i+1:4}"
+          i=$((i + 4))
+          ;;
+        *) out+="$ch" ;;
+      esac
+      escaped=0
+      continue
+    fi
+
+    case "$ch" in
+      \\) escaped=1 ;;
+      \")
+        printf '%s' "$out"
+        return 0
+        ;;
+      *) out+="$ch" ;;
+    esac
+  done
+
+  return 1
+}
+
+json_get_string() {
+  local json="$1"
+  local key="$2"
+  local rest
+
+  rest="${json#*\"${key}\"}"
+  if [ "$rest" = "$json" ]; then
+    return 1
+  fi
+  rest="${rest#*:}"
+  rest="$(ltrim "$rest")"
+  json_parse_quoted_string "$rest"
+}
+
+json_get_first_array_string() {
+  local json="$1"
+  local key="$2"
+  local rest
+
+  rest="${json#*\"${key}\"}"
+  if [ "$rest" = "$json" ]; then
+    return 1
+  fi
+  rest="${rest#*:}"
+  rest="$(ltrim "$rest")"
+  if [ "${rest:0:1}" != "[" ]; then
+    return 1
+  fi
+  rest="${rest:1}"
+  rest="$(ltrim "$rest")"
+  json_parse_quoted_string "$rest"
+}
+
+json_get_number() {
+  local json="$1"
+  local key="$2"
+  local rest
+
+  rest="${json#*\"${key}\"}"
+  if [ "$rest" = "$json" ]; then
+    return 1
+  fi
+  rest="${rest#*:}"
+  rest="$(ltrim "$rest")"
+  rest="${rest%%[,}]*}"
+  printf '%s' "$(ltrim "$rest")"
+}
+
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+noop() {
+  printf '%s\n' '{}'
+  exit 0
+}
+
+followup() {
+  local message
+  message="$(json_escape "$1")"
+  printf '%s\n' "{\"followup_message\":\"${message}\"}"
+  exit 0
+}
+
+HOOK_INPUT="$(cat)"
+if [ -z "$HOOK_INPUT" ]; then
+  noop
+fi
+
+ONE_LINE_INPUT="${HOOK_INPUT//$'\n'/}"
+ONE_LINE_INPUT="${ONE_LINE_INPUT//$'\r'/}"
+
+STATUS="$(json_get_string "$ONE_LINE_INPUT" "status" || true)"
+LOOP_COUNT="$(json_get_number "$ONE_LINE_INPUT" "loop_count" || true)"
+WORKSPACE_ROOT="$(json_get_first_array_string "$ONE_LINE_INPUT" "workspace_roots" || true)"
+
+# Only verify on a clean completion. An aborted/errored turn already has the
+# user's attention; don't pile a second nag on top.
+if [ "$STATUS" != "completed" ]; then
+  noop
+fi
+
+# Self-limit independent of Cursor's own loop_limit: after 2 automatic
+# follow-ups, stop nagging and let the user take the wheel. (loop_count
+# starts at 0, so this allows follow-ups at loop_count 0 and 1.)
+if [ -n "$LOOP_COUNT" ] && [ "$LOOP_COUNT" -ge 2 ] 2>/dev/null; then
+  noop
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$WORKSPACE_ROOT"
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(pwd -P 2>/dev/null || pwd)"
+fi
+
+CONVEX_DIR="${REPO_ROOT}/convex"
+if [ ! -d "$CONVEX_DIR" ]; then
+  noop
+fi
+
+if [ ! -f "${REPO_ROOT}/tsconfig.json" ] && [ ! -f "${REPO_ROOT}/package.json" ]; then
+  noop
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  noop
+fi
+
+cd "$REPO_ROOT" || noop
+
+TSC_OUTPUT="$(npx --no-install tsc --noEmit 2>&1)"
+TSC_STATUS=$?
+if [ $TSC_STATUS -eq 0 ]; then
+  noop
+fi
+
+# npx --no-install fails if tsc isn't already installed locally; don't nag
+# about an environment problem that isn't a real type error.
+if printf '%s' "$TSC_OUTPUT" | grep -qi "could not determine executable to run\|command not found"; then
+  noop
+fi
+
+TRIMMED="$(printf '%s' "$TSC_OUTPUT" | head -c 1500)"
+followup "The self-verify check found TypeScript errors after that turn ended. Run \`npx tsc --noEmit\`, fix every error below before considering the work done, then re-verify:
+
+${TRIMMED}"

--- a/test-harness/README.md
+++ b/test-harness/README.md
@@ -13,6 +13,9 @@ Automated test scenarios for validating the Convex plugin behavior in Claude Cod
 
 # Run specific test
 ./run-tests.sh scenarios/01-new-project.md
+
+# Automated smoke test for the `stop` hook (scripts/stop-verify.sh)
+./test-stop-verify.sh
 ```
 
 ## Test Structure

--- a/test-harness/test-stop-verify.sh
+++ b/test-harness/test-stop-verify.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Self-contained smoke test for scripts/stop-verify.sh (the `stop` hook that
+# implements the end-of-turn Convex verify mechanism for Cursor). No network
+# access required beyond `npm install typescript` for the pass/fail fixtures.
+#
+# Usage: ./test-harness/test-stop-verify.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/scripts/stop-verify.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1"
+  local expected_pattern="$2"
+  local actual="$3"
+  if printf '%s' "$actual" | grep -q -- "$expected_pattern"; then
+    echo "ok   - $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL - $name"
+    echo "       expected to match: $expected_pattern"
+    echo "       got: $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_hook() {
+  local dir="$1"
+  local status="$2"
+  local loop_count="$3"
+  (cd "$dir" && printf '{"status":"%s","loop_count":%s,"workspace_roots":["%s"]}' "$status" "$loop_count" "$dir" | bash "$HOOK")
+}
+
+echo "Testing $HOOK"
+echo ""
+
+# 1. No convex/ dir -> noop
+mkdir -p "$TMP/noconvex"
+OUT="$(run_hook "$TMP/noconvex" completed 0)"
+check "no convex/ dir -> noop" '^{}$' "$OUT"
+
+# 2. status != completed -> noop
+mkdir -p "$TMP/aborted/convex"
+OUT="$(run_hook "$TMP/aborted" aborted 0)"
+check "status=aborted -> noop" '^{}$' "$OUT"
+
+# 3. loop_count >= 2 -> noop
+mkdir -p "$TMP/loopcap/convex"
+OUT="$(run_hook "$TMP/loopcap" completed 2)"
+check "loop_count>=2 -> noop" '^{}$' "$OUT"
+
+# 4. no package.json/tsconfig -> noop
+mkdir -p "$TMP/nopkg/convex"
+OUT="$(run_hook "$TMP/nopkg" completed 0)"
+check "no package.json/tsconfig -> noop" '^{}$' "$OUT"
+
+# 5 & 6 need a real typescript install; skip gracefully if npm is unavailable
+# or offline (this mirrors how the hook itself degrades: never crash, never
+# false-positive on an environment problem).
+if command -v npm >/dev/null 2>&1; then
+  mkdir -p "$TMP/pass/convex" "$TMP/fail/convex"
+
+  cat > "$TMP/pass/package.json" <<'EOF'
+{"name":"pass-test","version":"1.0.0"}
+EOF
+  cat > "$TMP/pass/tsconfig.json" <<'EOF'
+{"compilerOptions":{"strict":true,"noEmit":true}}
+EOF
+  echo 'export const x: number = 1;' > "$TMP/pass/convex/ok.ts"
+
+  cat > "$TMP/fail/package.json" <<'EOF'
+{"name":"fail-test","version":"1.0.0"}
+EOF
+  cat > "$TMP/fail/tsconfig.json" <<'EOF'
+{"compilerOptions":{"strict":true,"noEmit":true}}
+EOF
+  echo 'export const x: number = "not a number";' > "$TMP/fail/convex/bad.ts"
+
+  if (cd "$TMP/pass" && npm install --no-audit --no-fund typescript >/dev/null 2>&1) \
+     && (cd "$TMP/fail" && npm install --no-audit --no-fund typescript >/dev/null 2>&1); then
+    OUT="$(run_hook "$TMP/pass" completed 0)"
+    check "passing tsc -> noop" '^{}$' "$OUT"
+
+    OUT="$(run_hook "$TMP/fail" completed 0)"
+    check "failing tsc -> followup_message" 'followup_message' "$OUT"
+    check "failing tsc -> mentions the real error" 'not assignable' "$OUT"
+  else
+    echo "skip - typescript install failed (offline?) — skipping pass/fail tsc tests"
+  fi
+else
+  echo "skip - npm not available — skipping pass/fail tsc tests"
+fi
+
+echo ""
+echo "=========================="
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Investigated whether Cursor's plugin format supports a real enforcement mechanism beyond static rules text (per the parallel Claude `Stop` hook and Codex MCP-typecheck-leg work). Findings, evidence-backed against `cursor.com/docs/hooks`:
  - Cursor plugins do **not** get MCP-as-enforcement — MCP servers are tool providers (this repo's `mcp.json` already uses one, for deployment data access, not lifecycle control).
  - Cursor's `stop` hook is real and fires "when the agent loop ends," but it **cannot block** turn completion — its only output field is `followup_message`, which Cursor auto-submits as the next turn (capped by `loop_limit`, default 5).
  - This repo already uses a real, currently-supported hook (`beforeShellExecution`, which *can* hard-deny) for pre-commit checks, confirming plugin-shipped hooks are a legitimate, working mechanism for this format — just not a blocking one for `stop`.
- Added `scripts/stop-verify.sh`, wired as a `stop` hook (`hooks.json`, `loop_limit: 2`): when `convex/` exists and `npx tsc --noEmit` fails after a completed turn, it returns a `followup_message` with the compiler errors so Cursor automatically re-prompts the agent to fix them before the session is really "done." This makes the SELF-VERIFY RULE already in `rules/quickstart.mdc` (v1.3.0, PR #15) a real mechanism as a backstop for when the agent skips/forgets the rule — not a replacement for it.
- README: new "Cursor plugin mechanism status" section stating plainly that this is a retry-loop, not a gate, and how it compares to the Claude Code (`Stop` hook, blocking) and Codex (MCP blocking-tool leg) equivalents. Also fixed the "Development Hooks" section, which still documented `Pre-Save Validation`/`Post-Save Codegen` hooks that were removed from `hooks.json` (commit `c54f796`) and never restored — only the pre-commit hook came back (as `beforeShellExecution`).
- Version bump 1.3.0 -> 1.4.0 (functional change: new hook ships).

## Test plan
- [x] `bash -n scripts/stop-verify.sh` — syntax check
- [x] `python3 -c "import json; json.load(open('hooks.json'))"` / same for `.cursor-plugin/plugin.json` — valid JSON
- [x] New `test-harness/test-stop-verify.sh` (self-contained, no Cursor install needed) — 7/7 passing locally:
      no `convex/` dir -> noop, non-`completed` status -> noop, loop-limit reached -> noop, no `package.json`/`tsconfig.json` -> noop, passing `tsc --noEmit` -> noop, failing `tsc --noEmit` -> `followup_message` with the real compiler error text.
- [x] Manually verified output is valid JSON in both the pass and fail cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)