### PR TITLE
parity: ship optimize + 11 backend-abstractions commands (v1.7.0)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convex",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Official Convex plugin for Cursor - reactive backend development with TypeScript, including rules, skills, MCP integration, and automation hooks",
   "author": {
     "name": "Convex",

--- a/commands/convex-advisor.md
+++ b/commands/convex-advisor.md
@@ -1,0 +1,27 @@
+---
+description: "Read the Convex deployment's 72h insights (read limits, OCC contention), root-cause each event in code, report evidence-backed perf/cost findings with fixes."
+---
+
+# Live-deployment advisor
+
+Static review guesses; the deployment KNOWS. The official Convex MCP ships an `insights` tool with typed 72h health events per function — documentsReadLimit / bytesReadLimit (hard limit hits), documentsReadThreshold / bytesReadThreshold (approaching), occFailedPermanently / occRetried (write contention) — each carrying evidence (table_name, bytes_read, documents_read, occ document id + retry count). The advisor turns each event into a root-caused finding by reading the flagged function's actual code, and emits findings on the findings bus (specs/finding.schema.json) so fixers can be dispatched and launch-readiness can score.
+
+## Steps
+1. GUARD: run deploy-guard step 0-1 — identify + announce the deployment being read. Reading insights/logs on prod is allowed read-only; never enable mutating prod access for an advisory pass.
+2. GATHER (deterministic, via the official Convex MCP): `status` → deployment selector; `insights` → the typed 72h events; `tables` → schema + row counts; `functionSpec` → the public/internal surface. The `insights` tool is only available on cloud dev/prod deployments when logged in as a user (not on previews or deploy-key-scoped contexts) and needs ~72h of traffic; if it returns nothing or is unavailable, say so and fall back to offering convex-reviewer — do NOT invent findings.
+3. ROOT-CAUSE each insight event by reading the flagged function's code:
+   - bytesReadThreshold/Limit or documentsReadThreshold/Limit → look for `.collect()` / unindexed `.filter()` / missing pagination on the named table; the fix is an index + `.withIndex`, `.take(n)`, or `.paginate` (convex-expert patterns), or an aggregate component for counting shapes.
+   - occRetried / occFailedPermanently → look for read-modify-write hotspots on the named document (shared counters, status toggles); the fix is @convex-dev/sharded-counter, narrowing the read set, or moving contention to a workpool.
+   - repeated failures in `logs` (status: failure) → classify: crash loop in a cron, validator rejections, unhandled error shapes.
+4. EMIT findings per specs/finding.schema.json: class perf/correctness/cost, severity from the insight kind (limit hits = high, thresholds = med, retried = med, permanent OCC failure = high), locus {kind: deployment, functionId, tableName}, evidence {kind: insight-event, detail: the raw event}, confidence: confirmed (the event happened — it is not a hypothesis), fixCapability + autofixable where the repair is mechanical.
+5. REPORT: findings ranked by severity, each with (a) the runtime evidence in one line ('messages:list read 4.2MB from messages 31× yesterday'), (b) the code-level root cause with file:line, (c) the concrete fix and which capability applies it. Offer to apply fixes; apply only on confirmation, then re-run `insights` after traffic to verify the trend, or re-run the static check immediately.
+6. Scope discipline: this is a health/perf/cost pass. Route authz findings to convex-authz, code-idiom findings to convex-reviewer, error triage to sentinel — emit a pointer finding rather than duplicating their work.
+
+## Rules
+- Evidence-not-vibes: every finding cites a real insight event, log line, or table stat — if the deployment has no evidence, the advisor has no findings (offer convex-reviewer instead).
+- Read-only by construction: an advisory pass never mutates any deployment and never enables prod mutation flags (deploy-guard discipline applies).
+- Root-cause in the code before reporting: an insight event names the symptom; the finding must name the line and the mechanism.
+- Emit on the findings bus (specs/finding.schema.json), confidence: confirmed — runtime events are facts, not hypotheses.
+- Severity from the event kind: limit-hit / permanent-OCC-failure = high; threshold / retried = med.
+- Stay in lane: perf/cost/health only — hand authz to convex-authz, style to convex-reviewer, error triage to sentinel.
+- Prefer component fixes over hand-rolls when they match (sharded-counter for OCC on counters, aggregate for count scans) — same bias as suggest.

--- a/commands/convex-backup.md
+++ b/commands/convex-backup.md
@@ -1,0 +1,28 @@
+---
+description: "Set up Convex backups and run a restore DRILL that proves recovery — snapshot, restore into a throwaway preview, assert the data came back — plus a schedule matched to your RPO and a gated recovery runbook."
+---
+
+# Back up — and prove the restore works
+
+Every backup story has two halves and most people only do the first: taking the backup, and proving you can get it back. This capability does both — it sets up regular snapshot exports and then runs a RESTORE DRILL that actually recovers the data into a disposable preview and asserts it's intact. The drill reuses migrate-rehearse's exact primitives (snapshot export → preview deploy → snapshot import) pointed at recovery instead of a forward change, so the safety net is tested, not assumed.
+
+## Steps
+1. GUARD: deploy-guard — classify + announce the deployment being backed up (reading/exporting is safe; the drill's restore target is a throwaway preview, never prod).
+2. TAKE the snapshot: `npx convex export --path backup-<date>.zip` (add `--include-file-storage` if the app stores files). This is the backup artifact; treat it as sensitive real data.
+3. SCHEDULE it (the ongoing half): recommend a cadence matched to how fast the data changes and how much loss is tolerable (RPO) — e.g. a daily `npx convex export` via CI/cron to durable storage the user controls, with a retention window. Convex's own platform backups exist; this adds a user-owned, portable copy.
+4. RESTORE DRILL (the half almost nobody does — this is the point):
+   (a) PRECONDITION: a Preview Deploy Key as `CONVEX_DEPLOY_KEY` (same requirement as migrate-rehearse; a paid-tier feature). If unavailable, drill against a fresh personal dev deployment instead and say so.
+   (b) create a throwaway preview from the CURRENT code: `npx convex deploy --preview-create restore-drill-<date>`.
+   (c) restore the snapshot into it: `npx convex import backup-<date>.zip --deployment restore-drill-<date> --replace` (import targets a deployment by NAME with `--deployment`; there is no `--preview-name` on import).
+   (d) ASSERT recovery: read the restored data back (MCP `tables` for row counts, `data`/`runOneoffQuery` for spot-checks) and confirm the critical tables came back with the expected row counts and a sample of real records — a restore that 'succeeds' but lands 0 rows is a FAILED drill. Compare against the source's counts where available.
+5. REPORT the drill result plainly: what was backed up, that the restore was ACTUALLY performed and verified (or that it FAILED and why — a failed drill is the most valuable output, found before a real disaster), the recommended schedule + retention, and the recovery runbook (the exact commands to restore to prod: `npx convex import backup.zip --replace --prod`, gated by deploy-guard, with the post-snapshot-write-loss caveat stated).
+6. HYGIENE: delete local snapshot copies when done (real data); the drill preview auto-expires. Never commit a backup file.
+
+## Rules
+- A backup you have never restored is a hope, not a backup — always run (or offer to run) the restore DRILL, don't just take the export.
+- The drill restores into a THROWAWAY preview (or dev), never prod; the restore target and the backup source are different deployments.
+- Assert recovery, don't assume it: a restore that lands 0 rows is a FAILED drill — check critical-table row counts + a real-record sample against the source.
+- A FAILED drill is the most valuable output — surface it loudly; that's the whole reason to drill before a real disaster.
+- Schedule matched to RPO (how much data loss is tolerable); keep a user-owned portable copy alongside Convex's platform backups, with a retention window.
+- Snapshots are sensitive real data: delete local copies when done, never commit them; the restore-to-prod runbook is deploy-guard-gated with the post-snapshot-write-loss caveat stated.
+- Shares migrate-rehearse's snapshot+preview mechanics but aims them at RECOVERY, not a forward change — a forward schema change is migrate-rehearse.

--- a/commands/convex-cost.md
+++ b/commands/convex-cost.md
@@ -1,0 +1,24 @@
+---
+description: "Preview Convex spend — rank functions by bytes/documents-read × call-volume from insights, project each cost driver's growth curve, name the cheapest fix; confirm-cost for paid actions."
+---
+
+# Preview what this app will cost
+
+Cost surprises come from a handful of functions reading far more data than anyone realized — the same read-heavy patterns convex-advisor flags for perf, seen through the money lens. This capability makes spend legible: it reads the deployment's own bytes/documents-read evidence, attributes it to the functions driving it, projects how it grows with traffic, and names the cheapest fix. It also carries the confirm-cost discipline (Supabase's structural consent for paid actions): before anything metered, state the price and get an explicit yes.
+
+## Steps
+1. GUARD: deploy-guard — a cost read is read-only over dev/prod (insights is cloud+user-auth only; not previews). Announce the deployment.
+2. GATHER the spend evidence via the official MCP: `insights` for the bytes-read / documents-read events (the direct cost signal — Convex bills on function calls + bandwidth), `tables` for row counts (a table's size bounds its scan cost), `functionSpec` for the surface. If there's no usage/traffic yet, say so and estimate from the query SHAPES instead (a `.collect()` on a table projected to grow is a future cost even with zero traffic today).
+3. ATTRIBUTE: rank functions by bytes/documents read per call × observed (or asked-about) call volume — the product is the cost driver, not either alone. A cheap-per-call function called constantly can outweigh an expensive rare one; show both factors.
+4. PROJECT: state how the top drivers scale — a full-table `.collect()` grows LINEARLY with the table (cost compounds as data accumulates); an indexed `.take(n)` stays flat. Give the user the shape of the curve ('this is O(table size) per call — fine at 1k rows, a bill at 1M'), not a false-precision dollar figure.
+5. NAME THE CHEAPEST FIX per driver — index + `.withIndex` instead of scan, `.paginate`/`.take` instead of `.collect`, an aggregate component for counts, caching a hot read — and emit it as a cost-class finding on the bus (evidence: the insight event + the projected growth) pointing at convex-expert/convex-advisor for the actual change.
+6. CONFIRM-COST for paid actions: if the flow includes anything metered (a domain purchase, cloud provisioning, a plan change), STATE the price and recurrence explicitly and get an explicit yes BEFORE proceeding — never let a paid action happen as a side effect (the cost-confirm gate).
+7. REPORT: the current cost drivers ranked, each with its evidence + growth shape + fix, and a plain bottom line ('your spend is dominated by messages:list reading the whole table every call; index it and it drops ~100x'). Honest precision: Convex pricing changes and depends on plan — give relative/shape guidance and cite the pricing page for absolute numbers rather than inventing a dollar total.
+
+## Rules
+- Cost = data-read-per-call × call-volume — always show both factors; a cheap function called constantly can cost more than an expensive rare one.
+- Read the deployment's own insights/bytes-read evidence for spend; with no traffic yet, price the query SHAPES (a scan on a growing table is a future cost).
+- Give the growth CURVE, not false-precision dollars: O(table) scans compound as data accumulates; indexed access stays flat. Cite the pricing page for absolute figures.
+- Every cost driver names its cheapest fix and emits a cost-class finding on the bus pointing at the fixer (convex-expert/advisor).
+- Confirm-cost for any metered/paid action: state the price + recurrence and get an explicit yes BEFORE it happens — never as a side effect.
+- Read-only over dev/prod (deploy-guard); insights is cloud+user-auth only. Cost composes convex-advisor's evidence but frames it as money, not latency.

--- a/commands/convex-docs.md
+++ b/commands/convex-docs.md
@@ -1,0 +1,26 @@
+---
+description: "Pull version-current Convex docs for the version this project uses — pin the installed version, fetch page-as-markdown or check node_modules types, freshness hierarchy — instead of writing a possibly-stale API from memory."
+---
+
+# Pull version-current Convex docs
+
+convex-expert carries baked, plugin-versioned knowledge — excellent for stable idioms, but it goes stale exactly where it hurts: a component that gained a new export, a CLI flag that changed, an API renamed between versions. This capability is the freshness discipline layered on top: pin to the project's real version, fetch the live page cheaply as markdown, and never write an unfamiliar API from memory when the current source is one fetch away.
+
+## Steps
+1. PIN the version: read the installed `convex` version (`node -p "require('./node_modules/convex/package.json').version"` or `package.json`), and the versions of any `@convex-dev/*` components in play. The docs you trust must match THESE versions — version skew is the single largest source of wrong Convex code.
+2. FRESHNESS HIERARCHY (cheapest-correct first, the Supabase-taught order):
+   (a) if a served docs tool / MCP `search_convex_docs` is available, use it (it returns version-scoped, reranked answers sized to the context window);
+   (b) else fetch the specific docs page as MARKDOWN — request `docs.convex.dev/<path>` and prefer a `.md`/markdown form when the site serves one (far fewer tokens than HTML), or the component's README at the pinned version;
+   (c) only then fall back to a general web search, and treat its version as unverified.
+   Do NOT skip to writing the API from memory when currentness is in doubt.
+3. VERIFY against the installed package when it matters: for a component export you're unsure exists, check `node_modules/@convex-dev/<x>/` (its `package.json` `exports`, its `.d.ts`) — the installed types are the ground truth for THIS version, more authoritative than any doc.
+4. USE the fetched fact narrowly: apply the current signature/flag, cite where it came from (page + version), and hand the actual code back to convex-expert to write idiomatically. convex-docs supplies the fresh fact; convex-expert supplies the idiom.
+5. On a version-mismatch build error (an export/flag that 'should' exist but doesn't): treat it as a currentness question — pin the version, fetch the current API, and correct — rather than guessing a different spelling.
+
+## Rules
+- Never write an unfamiliar or possibly-renamed Convex/component API from model memory when currentness is in doubt — pin the version and fetch the current source first.
+- The installed package's own `exports`/`.d.ts` in node_modules is the ground truth for this version — more authoritative than any doc page.
+- Follow the freshness hierarchy: served docs tool → page-as-markdown / pinned README → general web (unverified) — cheapest-correct first, fewest tokens.
+- Prefer markdown over HTML doc pages — far fewer tokens for the same content.
+- Supply the fresh FACT; hand idiomatic code back to convex-expert. This is a freshness layer, not a replacement for the baked knowledge.
+- A version-mismatch build error is a currentness question, not a spelling guess — re-pin and re-fetch.

--- a/commands/convex-insights.md
+++ b/commands/convex-insights.md
@@ -1,0 +1,27 @@
+---
+description: "Query a running Convex app's logs + health in natural language (official MCP): failures, slow/expensive functions, deploy causality — scoped, evidence-backed, with a dashboard deep link."
+---
+
+# Query logs + health in natural language
+
+The deployment already records what happened; the agent just has to ask well. This capability is a disciplined wrapper over the official Convex MCP's read tools (`logs`, `insights`, `functionSpec`, `status`) that turns operational questions into narrow, evidence-returning queries and hands back answers a human can one-click verify in the dashboard. The discipline is copied from the observability MCP surface that works best in the wild: discover fields before querying, three views not fifteen tools, token-frugal output, and a dashboard deep link on every answer.
+
+## Steps
+1. GUARD: deploy-guard step 0-1 — identify + announce which deployment is being read. Reading logs/insights is read-only; never enable prod mutation flags for an insights pass.
+2. DISCOVER before you query — never guess identifiers. Use `functionSpec` to list the real function names and `status` for the deployment/version. Note the tool limits up front: `logs` takes only `--history <n>` (a COUNT, not a time window), `--success`, `--jsonl`, `--prod`, `--deployment` — there is NO server-side status/function/requestId/time filter; `insights` has no function filter and is cloud dev/prod + user-auth only. So you fetch a recent window and filter CLIENT-SIDE.
+3. PICK ONE OF THREE VIEWS and fetch the raw window, then filter locally:
+   - failures view → `logs --history <n> --jsonl`, then locally keep failures + group by function + error message, returning counts + the first stack per group. Answers 'what's erroring', 'what failed after deploy'.
+   - health view → `insights` (cloud only): the typed 72h read-limit / OCC events. Surface + rank them, but hand perf/cost ROOT-CAUSING and fixes to convex-advisor — emit those as pointer findings, do not own the perf-fix framing here.
+   - trace view → `logs --history <n> --jsonl` then locally filter to one requestId/function to read the full execution. Answers 'why did THIS call fail'.
+4. SCOPE by fetching a bounded recent window (a sensible `--history` count) and filtering client-side to the function/status/requestId asked about; when the window is large, aggregate (counts by function/message) rather than dumping lines.
+5. ANSWER with (a) the one-line finding, (b) the evidence (counts + one representative stack/log line), and (c) WHEN POSSIBLE an agent-constructed dashboard deep link (dashboard.convex.dev, the deployment's Logs/Functions view) for human verification — no tool returns the link, so build it from the deployment name + function; never a raw log dump as the answer.
+6. CROSS-CHECK deploy causality when asked 'did my deploy break this': compare the failure onset (from the log timestamps) against the deployment version from `status`; correlate, don't assert.
+7. HAND OFF, don't fix here: a perf/cost cause → convex-advisor (which owns those fixes); a code defect → convex-reviewer/convex-authz; a live error to react to going forward → monitor/sentinel. Emit findings on the bus (specs/finding.schema.json) — primarily `observability`, with perf/cost as pointer findings to advisor — so a composite pass can pick them up.
+
+## Rules
+- Discover real function/field names (functionSpec/status) before filtering — never guess identifiers, never return a confusing empty result for a name the app doesn't have.
+- `logs` and `insights` have NO server-side status/function/requestId/time-window filter (logs takes only a --history COUNT; insights is cloud-only) — fetch a bounded recent window and filter CLIENT-SIDE; say so rather than implying params that don't exist.
+- One of three views per question (failures / health / trace) — don't fan out into many speculative tool calls.
+- No tool returns a dashboard link — construct it from the deployment name + function when possible for human verification; never answer with a raw log dump.
+- Read-only always: an insights pass runs no mutation and never enables prod mutation flags (deploy-guard discipline).
+- Stay a reader and defer perf/cost fixes to convex-advisor: emit primarily `observability`, route perf/cost as POINTER findings so advisor uniquely owns the perf-fix framing; forward-looking reaction goes to monitor/sentinel.

--- a/commands/convex-verify.md
+++ b/commands/convex-verify.md
@@ -1,0 +1,29 @@
+---
+description: "Prove a Convex feature works — seed, drive as multiple mocked users via convex-test, assert behavior including the negative authz cases (wrong user refused, data-scope enforced)."
+---
+
+# Prove a feature works — seed, drive, assert
+
+A green typecheck proves the code parses; it does not prove a non-owner is actually denied, that a query returns the right rows, or that a mutation has the effect it claims. This capability closes that gap with the loop the whole field is missing: seed → drive → assert, run in-process with `convex-test` so it needs no deployment. Its highest-value assertions are the NEGATIVE ones — the caller who should be refused — because those are exactly the authz defects the 30-app corpus shows are the #1 real bug and the ones a happy-path demo never catches.
+
+## Steps
+1. IDENTIFY the feature to prove: the specific exported query/mutation/action (or a small set) the user just built/changed, and its intended behavior — who should be allowed, what data should come back, what a mutation should change. If the intent is unstated, ask one focused question rather than guessing the contract.
+2. SET UP `convex-test`: ensure `convex-test` + `vitest` are dev deps AND a `vitest.config.ts` sets `test.environment: "edge-runtime"` with `server.deps.inline: ["convex-test"]` — WITHOUT that config, `convexTest(schema)` fails at runtime with `import.meta.glob is not a function` (verified). Also install `@edge-runtime/vm`. Then `convexTest(schema)` gives a `t` handle. Reuse the project's existing test setup if present (compose with the `test` capability, don't fork it).
+3. SEED realistic data through the app's OWN functions where possible (so the seed exercises the same validators/mutations a real user would), falling back to `t.run(async (ctx) => ctx.db.insert(...))` for fixtures the public API can't create. Seed at least: the caller's own rows AND a second user's rows, so cross-user access is testable.
+4. DRIVE the feature as DIFFERENT identities with `t.withIdentity({ subject, tokenIdentifier, ... })`: call the function as (a) the legitimate owner, (b) a different authenticated user, and (c) unauthenticated (`t` with no identity). Use the real identity shape the app's auth uses (subject/tokenIdentifier), matching how ownership is resolved.
+5. ASSERT behavior — POSITIVE and NEGATIVE:
+   - positive: the owner gets the expected rows / the mutation made the expected change (`expect(await t.withIdentity(owner).query(api.x.y, args)).toEqual(...)`).
+   - NEGATIVE (the load-bearing half): a different user calling the same function is REFUSED — `await expect(t.withIdentity(other).mutation(api.x.cancel, {id})).rejects.toThrow(/forbidden|not authorized|403/)` — and an unauthenticated caller is refused where auth is required. A feature is not proven until the wrong caller is shown to be blocked.
+   - data-scope: a list/query returns ONLY the caller's rows, never the second user's (assert the second user's row is absent).
+6. RUN the tests (`npx vitest run`) and report: what was proven (each positive + negative assertion that passed), and — critically — any assertion that FAILED, because a failed negative assertion is a real authz hole found before ship. Emit findings on the bus (specs/finding.schema.json, class authz/correctness, evidence kind probe-result with the exact failing call) for anything that didn't behave.
+7. Do NOT weaken a test to make it pass: if the owner-only query returns another user's row, the FIX is in the function (hand to convex-authz), not in the assertion. A test changed until it's green proves nothing.
+
+## Rules
+- Prove behavior, not compilation: every verification includes at least one NEGATIVE assertion (a caller who should be refused is refused) — the happy path alone is not proof.
+- Drive the feature as multiple identities with t.withIdentity (owner, other user, unauthenticated) using the app's real subject/tokenIdentifier shape.
+- Seed both the caller's rows AND a second user's rows so cross-user access and data-scope are actually testable.
+- A vitest.config.ts with environment 'edge-runtime' + convex-test inlined is REQUIRED for convex-test to run (import.meta.glob needs it); author it, don't just author the test file.
+- Run in-process with convex-test — no deployment needed; compose with the `test` capability's setup rather than forking it.
+- Never weaken an assertion to make it pass: a failing negative test is a real defect → hand the fix to convex-authz/convex-expert, don't edit the test until it's green.
+- Emit a bus finding for any assertion that failed (authz/correctness, evidence: the failing probe call) so a composite pass or self-heal can pick it up.
+- This drives a SPECIFIC built feature; a request to set up a test framework generally is the `test` capability.

--- a/commands/deploy-guard.md
+++ b/commands/deploy-guard.md
@@ -1,0 +1,24 @@
+---
+description: "Classify + announce the target Convex deployment before any deployment-affecting command; fresh explicit consent for prod actions; session read-only mode."
+---
+
+# Deployment target guard
+
+Deployments are not interchangeable, and most incidents start with a command aimed at the wrong one. Every Convex project has several (personal dev, preview, prod — often across multiple projects on one machine). This guard is the standing discipline: identify, announce, then act — and treat prod as consent-gated, per action, per session.
+
+## Steps
+1. IDENTIFY before you act: read `CONVEX_DEPLOYMENT` in .env.local, `convex.json`, and whether `CONVEX_DEPLOY_KEY` is set; or call the official Convex MCP `status` tool. Classify the target: local-anonymous | dev | preview | prod. If two sources disagree, resolve before proceeding.
+2. ANNOUNCE in one line before any deployment-affecting command: `target: dev (joyful-capybara-123, personal dev)`. Never run the command in the same breath as discovering the target — announce first.
+3. PROD needs a FRESH explicit yes: before `npx convex deploy` (when it resolves to prod), `npx convex run --prod`, `env set` on prod, snapshot `import`/`export` on prod, or starting the MCP with prod access — state exactly what will change on which deployment and get an explicit yes in THIS session. A yes given earlier, or for a different target, does not carry.
+4. MCP safety defaults: start the official MCP scoped non-prod (`--deployment dev`). The two prod flags are DIFFERENT risk levels — keep them split: a read-only prod audit (advisor/insights reading data/logs/insights) passes ONLY `--cautiously-allow-production-pii` (read tools); `--dangerously-enable-production-deployments` (which enables MUTATING prod tools) stays OFF unless the user explicitly asked to CHANGE prod this session. Never pair them by default — 'look at prod' must not silently grant 'mutate prod'.
+5. READ-ONLY session mode: when the user says 'read-only' / 'don't change anything', honor it absolutely for the rest of the session — no deploy, no env set/remove, no mutations via `run`, no imports; start the MCP with `--disable-tools run,envSet,envRemove`.
+6. Wrong-deployment diagnosis: when a deploy 'didn't change anything', do NOT re-deploy harder. Re-run step 1 — the deploy almost certainly landed on a different deployment than the one being observed.
+7. Ambiguity = stop: if you cannot determine which deployment a command will hit, find out (status tool; compare `npx convex env list` fingerprints) — never guess.
+
+## Rules
+- Classify and announce the target BEFORE every deployment-affecting command — identification and action are two separate steps.
+- Prod consent is per-action, per-target, per-session: state what changes where, get a fresh explicit yes.
+- Keep the two prod MCP flags split by risk: --cautiously-allow-production-pii (read-only) for an audit; --dangerously-enable-production-deployments (mutating) only when the user explicitly asks to change prod. Both are user-spoken-only; default every MCP start to a non-prod deployment selector.
+- Read-only mode, once requested, is absolute for the session — including 'harmless' mutations.
+- A deploy that seemed to do nothing means the WRONG deployment changed — diagnose the target, don't re-run.
+- This guard composes: ship, env, migrate, and seed run it as their step 0; it is not itself a deploy tool.

--- a/commands/explain-app.md
+++ b/commands/explain-app.md
@@ -1,0 +1,24 @@
+---
+description: "Explain an existing Convex app — data model + relationships, public vs internal functions, auth/ownership model, components, a request→data flow — read from the schema and function surface. Read-only."
+---
+
+# Explain this Convex app
+
+Before you can safely change an app you have to know what it is — and reading 15 function files top-to-bottom is slow and error-prone. This capability produces the map fast and accurately by reading the two sources that can't lie: the schema (the data model) and the function surface (`functionSpec` / the exported queries/mutations/actions). It is deliberately DESCRIPTIVE — it explains what IS, hands judgment to the audit capabilities and changes to the fixers. It is also the natural first step of an optimize or self-heal session, and the reusable 're-explain the current architecture' that 'change what you built' depends on.
+
+## Steps
+1. DETECT the app: the `convex/` directory, `schema.ts`, and whether a deployment exists (if one does, `functionSpec`/`tables` via the official MCP give the authoritative live surface; if not, read the source directly). deploy-guard classifies any deployment read as read-only.
+2. DATA MODEL: from `schema.ts`, list every table with its fields and, crucially, its RELATIONSHIPS — which `v.id("other")` fields point where, and which indexes exist (indexes reveal the intended access paths). Draw the foreign-key graph in words: 'tasks belong to projects (projectId) and users (ownerId); messages belong to conversations'.
+3. FUNCTION SURFACE: enumerate every exported function, split PUBLIC (query/mutation/action — the attack/API surface) from INTERNAL (internalQuery/... — not client-reachable), and for each give a one-line 'what it does + what it touches'. The public/internal split is the single most important thing a newcomer needs and the thing source-skimming most often gets wrong.
+4. AUTH / OWNERSHIP MODEL: state how identity is established (auth.config.ts provider? a users table keyed by tokenIdentifier?) and how ownership is enforced (is there a requireOwner-style check? which field is the owner?). Say plainly if there is NO auth foundation — that is load-bearing context for anyone about to change the app. (Describe the model; do not audit it for holes — that's convex-authz.)
+5. COMPONENTS + EXTERNAL EDGES: list the `@convex-dev/*` components installed (convex.config.ts) and what they provide, the HTTP routes (http.ts) and crons, and any external calls in actions (which APIs, which env vars).
+6. FLOW: trace 1-2 representative end-to-end paths ('client calls createTask → validates → inserts into tasks scoped to the caller → listMyTasks reads it back by the by_owner index') so the reader sees the moving parts connected, not just catalogued.
+7. PRESENT as a scannable map (data model → public/internal functions → auth model → components/edges → a flow or two), accurate to the source. End by pointing at the next verbs: convex-reviewer/convex-authz to audit it, launch-readiness to score it, design/convex-expert to extend it. Never invent behavior the source doesn't show; if something is ambiguous, say so rather than guessing.
+
+## Rules
+- Read the schema + function surface (functionSpec/source) as the source of truth — never describe behavior the code doesn't show; flag ambiguity instead of guessing.
+- Lead with the two things a newcomer most needs and skimming most often gets wrong: the data-model relationship graph and the public-vs-internal function split.
+- State the auth/ownership model plainly, including 'there is no auth foundation' when that's the case — but DESCRIBE it; auditing it for holes is convex-authz's job.
+- Descriptive, not evaluative: explain-app maps what IS and hands judgment to the audit capabilities and changes to the fixers.
+- Read-only: any deployment introspection is read-only (deploy-guard); the app is not modified.
+- End by pointing at the right next verb (audit → reviewer/authz, score → launch-readiness, extend → design/expert).

--- a/commands/launch-readiness.md
+++ b/commands/launch-readiness.md
@@ -1,0 +1,30 @@
+---
+description: "Run every Convex audit (authz, reviewer, advisor, insights) into one scored, deduped readiness report with an ordered fix plan — Lighthouse for your backend."
+---
+
+# Launch-readiness report
+
+Readiness is not one check — it's the union of the checks, deduped, ranked, and scored. This capability is pure composition over the findings bus (specs/finding.schema.json): it runs each audit capability, normalizes their outputs into one report (specs/finding-report.schema.json), computes an auditable score, and — because every finding names a fixCapability — hands the user a prioritized, actionable punch list instead of four separate reports. It fixes nothing itself; it decides WHAT to fix and in what order, then dispatches to the fixers.
+
+## Steps
+1. GUARD + SCOPE: deploy-guard classifies the target (local-anonymous / dev / preview / prod); announce it. Detect what's assessable — is there a convex/ dir, a deployed deployment with traffic, an auth foundation? Skip passes whose preconditions aren't met and SAY which were skipped (a skipped pass is not a pass).
+2. RUN THE PASSES, each emitting findings on the bus:
+   - convex-authz — the authz scan (identity-from-arg, missing ownership, PII leak, parent-ref-on-write). Always runnable on code.
+   - convex-reviewer — validators, indexes-not-filter, idiom, error handling. Always runnable on code.
+   - convex-advisor — live read-limit / OCC evidence (only if a deployment with traffic exists; else record 'skipped: no traffic').
+   - convex-insights — recent failures from logs (only if a deployment exists).
+   Run independent passes concurrently; each returns findings, not fixes.
+3. NORMALIZE + DEDUPE: collect all findings into one report. Set each finding's `identity` field to a normalized function/table key (e.g. `messages:list`) that is the SAME whether the pass reported a code-locus or a deployment-locus for that function — so the SAME defect seen from two loci (reviewer flags a missing index at code-locus, advisor flags its read-limit symptom at deployment-locus) collapses to ONE via the bus's (class, identity) dedup and isn't double-counted in the score. Keep the higher-confidence source. Drop nothing silently; a pass that errored/was skipped is a stated coverage gap, not a clean result.
+4. SCORE, auditable: start at 100; subtract per CONFIRMED finding by severity (high −15, med −5, low −1), floor at 0; print the exact formula and the per-class breakdown so the number is reproducible, not a vibe. plausible-only findings are listed as candidates but do NOT move the score (evidence-not-vibes). A deployment/traffic-less run reports a code-only score and says so.
+5. REPORT: the score, then findings ranked by severity, each with its evidence, its locus, and the fixCapability + a one-line fix note. Group by 'blockers' (high) / 'should-fix' (med) / 'nice-to-have' (low). End with the ordered fix plan: which capability to run next, in what order (authz/data-loss first, then perf/scale, then idiom/observability).
+6. DISPATCH on request: for each finding the user accepts, invoke its fixCapability (convex-authz, convex-reviewer's fixers, migrate-rehearse for schema changes, suggest for component swaps). After fixes, RE-RUN the affected passes and show the score delta — the readiness number is only meaningful if it moves when you fix things.
+7. Never claim more coverage than was run: the report header lists which passes ran, which were skipped and why. A green score on a code-only run is 'code looks ready', not 'production-verified'.
+
+## Rules
+- Compose, don't re-implement: run the existing audit capabilities and aggregate their bus findings — never re-derive an authz or perf check inline.
+- The score counts CONFIRMED findings only, by severity, with the formula printed; plausible findings are candidates that don't move the number.
+- Normalize each finding's locus to a function/table identity before dedup (map deployment functionId ↔ code file:line) so one defect seen from two loci collapses to one and isn't double-scored; keep the higher-confidence source; drop nothing silently.
+- Every finding carries its fixCapability; the report ends with an ORDERED fix plan (data-loss/authz first, then scale, then idiom/observability).
+- Re-run affected passes after fixes and show the score delta — a readiness number that doesn't move when you fix things is theater.
+- Never claim more than was run: header lists ran/skipped passes; a code-only run yields a code-only score, explicitly labeled.
+- This is a read + aggregate + dispatch pass; fixes happen in the fixer capabilities, gated by their own consent/deploy-target rules.

--- a/commands/migrate-rehearse.md
+++ b/commands/migrate-rehearse.md
@@ -1,0 +1,26 @@
+---
+description: "Rehearse a live-app schema change + backfill on a snapshot-seeded preview deployment, verify, then promote the proven change to prod with the snapshot as rollback."
+---
+
+# Rehearse a schema change on a preview before prod
+
+A schema push on Convex validates every existing document against the new schema and FAILS the push if any row doesn't conform — a real data-conformance gate. The safe way to use that gate is to let it fail on a rehearsal copy, not on prod. This capability turns a preview deployment into that copy: seed it with a prod snapshot, push the new schema + run the backfill there, watch the gate, and only promote once it's green. It composes deploy-guard (target classification), migrate (the optional-then-tighten pattern), and @convex-dev/migrations (the batched, resumable backfill).
+
+## Steps
+0. PRECONDITION: preview deployments need a Preview Deploy Key (dashboard → Project Settings → Deploy Keys → Preview) exported as `CONVEX_DEPLOY_KEY` before any `--preview-create`/`--preview-name` deploy — a plain `npx convex login` session cannot create previews, and this is a paid-tier feature. If no preview key is available, fall back to rehearsing on the personal dev deployment seeded with the snapshot, and say so.
+1. GUARD: deploy-guard — classify + announce the SOURCE (prod, being read) and the eventual TARGET (prod, being changed); get the fresh explicit yes for the prod promote up front and confirm the plan.
+2. SNAPSHOT the source data read-only: `npx convex export --path snapshot.zip` (from the deployment holding the real data; add `--include-file-storage` only if the migration touches files). This is a read; it changes nothing.
+3. CREATE the preview FROM THE PRE-CHANGE CODE — do this BEFORE editing schema.ts, so the preview starts on the schema the snapshot data already conforms to: `npx convex deploy --preview-create migrate-<slug>` (needs the preview key; auto-expires ~5 days). Seed it: `npx convex import snapshot.zip --deployment migrate-<slug>` (import targets a deployment by NAME with `--deployment`; there is no `--preview-name` flag on import). The import succeeds because the data still matches the old schema.
+4. REHEARSE on the preview, in the migrate order — each push is `npx convex deploy --preview-name migrate-<slug>` (re-deploys to the SAME preview, keeping its data; NOT `convex dev`, which targets personal dev): (a) make the new/changed field OPTIONAL and deploy — if existing rows violate it the push FAILS HERE on the copy with the offending shape; fix and re-push until green. (b) write a @convex-dev/migrations backfill and run it against the preview; verify every row is now valid. (c) tighten the validator (required / narrowed union) and deploy again — the gate now passes because the backfill ran.
+5. VERIFY on the preview: run the app's functions against the migrated data (MCP `run`/`runOneoffQuery` pointed at the preview, or a smoke query) to confirm behavior and shape.
+6. PROMOTE only on the fresh explicit yes from step 1: apply the SAME sequence to prod (optional schema → backfill → tighten). Because it already succeeded on prod-shaped data, the prod push repeats a proven run. Keep the snapshot as the rollback artifact (`npx convex import snapshot.zip --replace --prod`); state plainly that data written after the snapshot is lost, so keep the promote window short.
+7. CLEAN UP: the preview auto-expires; delete the local snapshot when done (it holds real data — treat it as sensitive, never commit it).
+
+## Rules
+- Create the preview from the PRE-CHANGE code and seed the snapshot BEFORE editing schema.ts — so the import conforms and the conformance gate then fails on the copy (not prod) when you push the change; each preview push is `deploy --preview-name`, import targets it with `--deployment`.
+- Follow the migrate order every time: optional field → push → backfill → verify → tighten → push; skipping 'optional first' makes the very first push reject existing rows.
+- The prod promote needs a fresh explicit yes (deploy-guard) and is a REPEAT of the proven preview run, not a new attempt.
+- Keep the prod snapshot as the rollback artifact; state plainly that a snapshot-restore loses data written after the snapshot, so keep the promote window short.
+- Treat the exported snapshot as sensitive real data: delete it locally when finished; never commit it.
+- Backfills go through @convex-dev/migrations (batched, resumable, dry-runnable), not ad-hoc one-shot mutations over a whole table.
+- This is the rehearsal-and-promote flow; for the plain 'explain optional-then-tighten' guidance with no live data, that's migrate.

--- a/commands/optimize.md
+++ b/commands/optimize.md
@@ -4,18 +4,18 @@ description: "Audit and optimize an existing Convex app: security, scale, upgrad
 
 # Audit and optimize an existing Convex app
 
-Run a read-first audit of the current Convex app and produce a concrete, prioritized plan. Default to plan, then confirm, then apply. Never change code without approval.
+The remediation WORKFLOW for an existing app: open with a scored assessment, then act on it — upgrade stale components and set up observability — plan-then-confirm-then-apply. The assessment itself is delegated to launch-readiness (the findings-bus scorer); optimize's distinct value is the actions it takes on the result.
 
 ## Steps
 1. Detect the app: a `convex/` directory, the schema, and whether it's an anonymous or cloud deployment.
-2. Run the `convex-reviewer` pass (auth checks, args/returns validators, indexes-not-filter, OCC conflicts, pagination, schema design).
-3. Run `check-updates` against the pinned `@convex-dev/*` components and flag breaking changes.
-4. Offer to install `sentinel` for production error capture (its tables live in the user's own deployment).
-5. Read recent production errors and logs via the Convex CLI (`convex data`, `logs`).
-6. Present a prioritized plan — security and data-loss risks first, then scale, then observability — and apply only on explicit confirmation.
+2. ASSESS via `launch-readiness` — one scored, deduped report across authz/reviewer/advisor/insights with an ordered fix plan. Do not re-run those passes by hand; optimize consumes launch-readiness's report rather than re-implementing the audit.
+3. UPGRADE: run `check-updates` against the pinned `@convex-dev/*` components and fold stale-component (staleness-class) findings into the same plan.
+4. OBSERVABILITY: if the readiness report flagged an observability gap (no prod error capture), offer to install `sentinel`.
+5. Present the combined prioritized plan — the launch-readiness score + the fix plan + upgrades + observability, security/data-loss first — and apply only on explicit confirmation, dispatching each fix to its fixCapability.
+6. After applying, re-run the launch-readiness assessment and show the score delta.
 
 ## Rules
 - Read-only first. Present a plan and CONFIRM before changing any file.
-- Compose, don't reinvent: use convex-reviewer, check-updates, and sentinel.
-- Prioritize security and data-loss risks above style.
-- Never auto-land changes on someone's existing prod app.
+- Delegate the audit to launch-readiness (the findings-bus scorer); don't re-implement reviewer/advisor/insights inline — optimize's job is acting on the report (upgrades + observability), not re-scoring.
+- Prioritize security and data-loss risks above style, following launch-readiness's ordering.
+- Never auto-land changes on someone's existing prod app; re-assess after applying and show the score moved.

--- a/commands/self-heal.md
+++ b/commands/self-heal.md
@@ -1,0 +1,33 @@
+---
+description: "Production error → triaged, root-caused, repaired, and certified (tsc + rehearsal + reproduce-then-gone) fix PR for a human to merge — then confirm the error stops recurring. Never auto-merges."
+---
+
+# Gated production self-healing loop
+
+Sentry/Datadog/Vercel can go error→investigate→draft-PR, but they treat the backend as opaque and stop at the human merge gate with an unverified diff. Convex can do the step they can't: because the error rows live in the user's own deployment and the fix can be rehearsed on a preview of that deployment, the platform certifies the fix against real invariants before anyone reviews it. This capability is the composition capstone — it wires sentinel (capture) → the findings bus (diagnose) → the fixers (repair) → migrate-rehearse/tsc/probe (certify) → a human PR (decide) → deploy-guard (promote). The human keeps the merge button; the machine does everything up to and including proving the fix works.
+
+## Steps
+1. GUARD: deploy-guard — this loop reads prod and PROPOSES prod changes; classify + announce the deployment and get the standing consent for the loop's scope up front (what classes of fix it may auto-prepare vs must always defer). Never auto-merge; the human merge is the fixed boundary.
+2. CAPTURE: require sentinel (prod errors in the user's own deployment, redacted at write time). If absent, offer to install it and stop — there is nothing to heal without capture.
+3. TRIAGE a new/ recurring error: pull it via the official MCP (data/run-once-query over the sentinel table, or the monitor's prod_error event). Classify: transient (retry/ignore — do NOT open a PR for a one-off network blip), config (env/secret — hand to env, never guess a secret), or a code/schema defect (proceed).
+4. ROOT-CAUSE on the findings bus: run the relevant audit pass on the implicated function — convex-insights (the failing requests + stacks), convex-advisor (if it's a read-limit/OCC cause), convex-reviewer/convex-authz (if it's a logic/authz defect). Produce a bus finding with evidence (the stack + the reproducing input) and a fixCapability. If root cause is unclear, STOP and report — a wrong fix is worse than an open error.
+5. REPAIR via the finding's fixCapability (convex-authz, reviewer fixers, convex-expert for perf) on a branch — never on prod directly.
+6. CERTIFY against the backend's own invariants BEFORE proposing (this is the differentiator — do not skip any that apply):
+   (a) `tsc --noEmit` clean;
+   (b) if the fix touches schema/data, run it through migrate-rehearse on a preview seeded with a prod snapshot — the schema-conformance gate must pass on real-shaped data;
+   (c) reproduce-then-confirm-gone: replay the error's triggering input against the fixed code (a convex-test case or an MCP run on the preview) and assert the failure no longer occurs;
+   (d) no-regression: the finding must be gone AND no new bus finding introduced on the touched function.
+   A fix that fails any applicable certification is NOT proposed — it's reported as 'attempted, could not certify' with what failed.
+7. PROPOSE, never merge: open a PR (or a diff for review) containing the fix, the certification evidence (tsc result, rehearsal outcome, the reproduced-then-gone assertion), the original error + finding, and the reversibility note. Label the change class. The human reviews and merges.
+8. PROMOTE on merge via deploy-guard's prod consent; after deploy, re-check the sentinel table + `logs` (failures) to confirm that error signature stops recurring (do NOT use `insights` for this — it tracks only OCC/read-limit perf events, not arbitrary error signatures) — the loop is only closed when the error stops recurring in prod. If it recurs, reopen with the new evidence.
+9. BOUND it: only classes the user pre-approved in step 1 are auto-prepared (default-safe set: validator fixes, missing-index adds, ownership-check adds, non-destructive backfills); anything destructive, security-sensitive beyond an added check, or ambiguous is always deferred to explicit human direction. Log every action to an append-only record so the loop is auditable.
+
+## Rules
+- The human keeps the merge button — this loop prepares and certifies fixes, it NEVER auto-merges or auto-deploys to prod (matches the industry boundary: no credible system ships unattended prod auto-merge).
+- Certify before proposing: tsc + (schema→migrate-rehearse on a prod-snapshot preview) + reproduce-then-confirm-the-failure-is-gone + no new bus finding. An uncertified fix is reported as 'could not certify', never proposed as done.
+- Triage first: transient blips get retried/ignored, config errors go to env (never guess a secret), only real code/schema defects enter the repair loop.
+- Repair on a branch/preview, never on prod directly; promote only through deploy-guard's fresh prod consent.
+- Only pre-approved fix classes are auto-prepared (default-safe: validator/index/ownership/non-destructive backfill); destructive or ambiguous changes are always deferred to the human.
+- Close the loop for real: after merge+deploy, confirm the error signature stops recurring via the sentinel table + logs (not insights, which only sees perf events); reopen if it persists.
+- Every action is logged to an append-only, auditable record; data residency stays in the user's own deployment (sentinel discipline).
+- If root cause is unclear, STOP and report — an uncertain fix is worse than an open, visible error.


### PR DESCRIPTION
Brings Cursor to parity with the hub: optimize update + 11 backend-abstractions commands (convex-advisor, convex-backup, convex-cost, convex-docs, convex-insights, convex-verify, deploy-guard, explain-app, launch-readiness, migrate-rehearse, self-heal). convex-authz stays held. 🤖 Generated with [Claude Code](https://claude.com/claude-code)