### PR TITLE
Fix the 'keep convex dev running' linting loop — refresh codegen in the verify hook

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convex",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Official Convex plugin for Cursor - reactive backend development with TypeScript, including rules, skills, MCP integration, and automation hooks",
   "author": {
     "name": "Convex",

--- a/scripts/stop-verify.sh
+++ b/scripts/stop-verify.sh
@@ -188,6 +188,20 @@ fi
 
 cd "$REPO_ROOT" || noop
 
+# Refresh Convex codegen before typechecking so the agent is never chased by stale
+# convex/_generated/ errors for functions it just wrote — the exact failure mode the
+# "keep npx convex dev running" advice worked around, handled here so the user doesn't
+# have to. Best-effort and hard-capped: a watchdog kills codegen if it's slow or has no
+# reachable deployment, and we fall through to tsc unchanged.
+if [ -d "${REPO_ROOT}/convex" ]; then
+  ( npx --no-install convex codegen >/dev/null 2>&1 ) &
+  CODEGEN_PID=$!
+  ( sleep 20; kill "$CODEGEN_PID" >/dev/null 2>&1 ) >/dev/null 2>&1 &
+  WATCHDOG_PID=$!
+  wait "$CODEGEN_PID" 2>/dev/null
+  kill "$WATCHDOG_PID" >/dev/null 2>&1
+fi
+
 TSC_OUTPUT="$(npx --no-install tsc --noEmit 2>&1)"
 TSC_STATUS=$?
 if [ $TSC_STATUS -eq 0 ]; then


### PR DESCRIPTION
**Root cause:** `scripts/stop-verify.sh` runs `tsc --noEmit` at end-of-turn **without regenerating `convex/_generated/` first**. Right after the agent writes a new query/mutation, the generated types are stale, so `tsc` reports phantom errors for the code it just wrote, and the agent loops trying to fix them. That's the exact failure our docs worked around by telling users to keep `npx convex dev` running in a separate terminal — friction that undercuts 'the plugin just works.'

**Fix:** refresh codegen in the hook before the typecheck, so the user never has to babysit a terminal. Best-effort and hard-capped with a 20s watchdog so a missing/unreachable deployment can't hang the turn; on any failure it falls through to `tsc` unchanged.

⚠️ **Needs testing before merge** (I can't run the Cursor runtime): confirm codegen refreshes types in a real project (loop gone) and never stalls the stop hook. The same fix is needed in the **Claude** plugin (`hooks/convex-typecheck.mjs`) and **Codex** — happy to follow up once the approach is confirmed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)